### PR TITLE
Add functionality to unsubscribe a Channel or unbind all events in a subscription

### DIFF
--- a/src/pushex.js
+++ b/src/pushex.js
@@ -54,10 +54,13 @@ export class Pushex {
       if (this.subscriptions[channelName]) {
         const subscription = this.subscriptions[channelName]
 
-        return subscription.close().then(() => {
-          delete this.subscriptions[channelName]
-          resolve()
-        }).catch(reject)
+        return subscription
+          .close()
+          .then(() => {
+            delete this.subscriptions[channelName]
+            resolve()
+          })
+          .catch(reject)
       } else {
         return resolve()
       }

--- a/src/pushex.js
+++ b/src/pushex.js
@@ -49,6 +49,21 @@ export class Pushex {
     return this.subscriptions[channelName].setup()
   }
 
+  unsubscribe(channelName) {
+    return new Promise((resolve, reject) => {
+      if (this.subscriptions[channelName]) {
+        const subscription = this.subscriptions[channelName]
+
+        return subscription.close().then(() => {
+          delete this.subscriptions[channelName]
+          resolve()
+        }).catch(reject)
+      } else {
+        return resolve()
+      }
+    })
+  }
+
   getSocket() {
     return this.socket
   }

--- a/src/pushex.spec.js
+++ b/src/pushex.spec.js
@@ -134,3 +134,26 @@ describe("subscribe", () => {
     expect(sub).not.toEqual(sub2)
   })
 })
+
+describe("unsubscribe", () => {
+  it("resolves when there isn't an existing subscription", (done) => {
+    const pushex = new Pushex("wss://test.com", {})
+    pushex.unsubscribe("chName").then(() => {
+      done()
+    })
+  })
+
+  it("closes an existing subscription", (done) => {
+    const pushex = new Pushex("wss://test.com", {})
+    const sub = pushex.subscribe("chName")
+
+    expect(pushex.subscriptions.chName).not.toEqual(undefined)
+    expect(sub.channel).not.toEqual(null)
+
+    pushex.unsubscribe("chName").then(() => {
+      expect(pushex.subscriptions).toEqual({})
+      expect(sub.channel).toEqual(null)
+      done()
+    })
+  })
+})

--- a/src/pushex.spec.js
+++ b/src/pushex.spec.js
@@ -136,14 +136,14 @@ describe("subscribe", () => {
 })
 
 describe("unsubscribe", () => {
-  it("resolves when there isn't an existing subscription", (done) => {
+  it("resolves when there isn't an existing subscription", done => {
     const pushex = new Pushex("wss://test.com", {})
     pushex.unsubscribe("chName").then(() => {
       done()
     })
   })
 
-  it("closes an existing subscription", (done) => {
+  it("closes an existing subscription", done => {
     const pushex = new Pushex("wss://test.com", {})
     const sub = pushex.subscribe("chName")
 

--- a/src/subscription.js
+++ b/src/subscription.js
@@ -15,6 +15,22 @@ export class Subscription {
     return this
   }
 
+  close() {
+    return new Promise((resolve, reject) => {
+      if (this.channel) {
+        this.channel.leave()
+          .receive("ok", () => {
+            this.channel = null
+            resolve()
+          })
+          .receive("error", reject)
+          .receive("timeout", reject)
+      } else {
+        resolve()
+      }
+    })
+  }
+
   bind(eventName, fn) {
     this.bindings[eventName] = this.bindings[eventName] || []
     this.bindings[eventName].push(fn)
@@ -22,6 +38,10 @@ export class Subscription {
     return () => {
       this.bindings[eventName] = this.bindings[eventName].filter(testFn => testFn !== fn)
     }
+  }
+
+  unbindAll(eventName) {
+    this.bindings[eventName] = []
   }
 
   // private

--- a/src/subscription.js
+++ b/src/subscription.js
@@ -18,7 +18,8 @@ export class Subscription {
   close() {
     return new Promise((resolve, reject) => {
       if (this.channel) {
-        this.channel.leave()
+        this.channel
+          .leave()
           .receive("ok", () => {
             this.channel = null
             resolve()

--- a/src/subscription.spec.js
+++ b/src/subscription.spec.js
@@ -160,7 +160,7 @@ describe("close", () => {
     return receiveMock
   }
 
-  it("resolves once closed", (done) => {
+  it("resolves once closed", done => {
     const subscription = new Subscription("chName", { pushEx: mockPushEx })
     subscription.setup()
 
@@ -170,7 +170,7 @@ describe("close", () => {
     subscription.close().then(done)
   })
 
-  it("rejects if error", (done) => {
+  it("rejects if error", done => {
     const subscription = new Subscription("chName", { pushEx: mockPushEx })
     subscription.setup()
 
@@ -180,7 +180,7 @@ describe("close", () => {
     subscription.close().catch(done)
   })
 
-  it("rejects if timeout", (done) => {
+  it("rejects if timeout", done => {
     const subscription = new Subscription("chName", { pushEx: mockPushEx })
     subscription.setup()
 
@@ -190,7 +190,7 @@ describe("close", () => {
     subscription.close().catch(done)
   })
 
-  it("resolves without a channel", (done) => {
+  it("resolves without a channel", done => {
     const subscription = new Subscription("chName", { pushEx: mockPushEx })
     subscription.close().then(done)
   })


### PR DESCRIPTION
I didn't really expect to need these but there's a use case for slow rollout of PushEx which can utilize them.