### PR TITLE
Fix types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { Pushex } from "./pushex"
+export type { PushexConfig } from "./pushex"
 export type { SubscriptionFunction, Subscription } from "./subscription"

--- a/src/pushex.ts
+++ b/src/pushex.ts
@@ -15,7 +15,7 @@ export type PushexConfig = {
 }
 
 export class Pushex {
-  private subscriptions: Record<string, Subscription>
+  private subscriptions: Record<string, Subscription> = {}
   private socket!: Socket
   private config: Required<PushexConfig>
 
@@ -31,7 +31,6 @@ export class Pushex {
       socketReconnectAlgorithm: config.socketReconnectAlgorithm || DEFAULT_SOCKET_RECONNECT_ALGORITHM,
     }
 
-    this.subscriptions = {}
     this.setupSocket(url)
   }
 
@@ -42,7 +41,7 @@ export class Pushex {
   }
 
   public disconnect() {
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
       this.socket.disconnect(() => resolve())
     })
   }

--- a/src/pushex.ts
+++ b/src/pushex.ts
@@ -7,17 +7,17 @@ const DEFAULT_SOCKET_RECONNECT_ALGORITHM = (tries: number) => {
   return [3000, 6000, 10000, 20000][tries - 1] || 30000
 }
 
-type PushexConfig = {
-  getParams: () => Promise<Record<string, any>>
-  onConnect: (instance: Pushex) => void
-  onConnectionError: (instance: Pushex) => void
-  socketReconnectAlgorithm: typeof DEFAULT_SOCKET_RECONNECT_ALGORITHM
+export type PushexConfig = {
+  getParams?: () => Promise<Record<string, any>>
+  onConnect?: (instance: Pushex) => void
+  onConnectionError?: (instance: Pushex) => void
+  socketReconnectAlgorithm?: typeof DEFAULT_SOCKET_RECONNECT_ALGORITHM
 }
 
 export class Pushex {
   private subscriptions: Record<string, Subscription>
   private socket!: Socket
-  private config: PushexConfig
+  private config: Required<PushexConfig>
 
   constructor(url: string, config: PushexConfig) {
     if (!url) {

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -53,7 +53,7 @@ export class Subscription {
 
   // Public, but for internal use
   public close() {
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
       if (this.channel) {
         this.channel
           .leave()


### PR DESCRIPTION
The types for `PushexConfig` were incorrect in that they required one to return all of the config options when one can pass in any subset. To fix it, I marked each property in `PushexConfig` as optional.