### PR TITLE
Use globalThis instead of window (for web workers)

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,8 @@ module.exports = {
     filename: "pushex.js",
     path: path.resolve(__dirname, "dist"),
     library: "Pushex",
-    libraryTarget: "umd"
+    libraryTarget: "umd",
+    globalObject: "globalThis",
   },
   devtool: "cheap-module-source-map",
   resolve: {


### PR DESCRIPTION
## Description
Tells Webpack to output code with `globalThis` instead of `window`.

## Motivation and Context
It's not currently possible to run this library in web workers. The generated bundle contains a `window` reference that doesn't exist there.
<img width="639" alt="image" src="https://github.com/pushex-project/pushex.js/assets/10897933/1602b634-b660-40da-8c53-d7401cb8311f">

`globalThis` is everywhere and it allows us to avoid manually checking for `window`, `self`, `global`, etc. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis#description

https://caniuse.com/?search=globalThis

## How Has This Been Tested?
Built the lib locally and used it in an app.
Checked the bundle diff
<details>
<summary>diff</summary>

```diff
diff --git a/./src/dist-old.js b/./src/dist-new.js
index bcc8c25..b6a1b94 100644
--- a/./src/dist-old.js
+++ b/./src/dist-new.js
@@ -6,7 +6,7 @@
     : "object" == typeof exports
     ? (exports.Pushex = t())
     : (e.Pushex = t())
-})(window, function () {
+})(globalThis, function () {
   return (function (e) {
     var t = {}
     function n(i) {
@@ -412,15 +412,15 @@
             E = "phx_join",
             C = "phx_reply",
             T = "phx_leave",
-            w = "websocket",
-            R = function (e) {
+            R = "websocket",
+            S = function (e) {
               return "function" == typeof e
                 ? e
                 : function () {
                     return e
                   }
             },
-            S = (function () {
+            w = (function () {
               function e(t, n, i, o) {
                 c(this, e),
                   (this.channel = t),
@@ -543,13 +543,13 @@
                 c(this, e),
                   (this.state = v),
                   (this.topic = t),
-                  (this.params = R(n || {})),
+                  (this.params = S(n || {})),
                   (this.socket = i),
                   (this.bindings = []),
                   (this.bindingRef = 0),
                   (this.timeout = this.socket.timeout),
                   (this.joinedOnce = !1),
-                  (this.joinPush = new S(this, E, this.params, this.timeout)),
+                  (this.joinPush = new w(this, E, this.params, this.timeout)),
                   (this.pushBuffer = []),
                   (this.stateChangeRefs = []),
                   (this.rejoinTimer = new M(function () {
@@ -596,7 +596,7 @@
                         "timeout ".concat(o.topic, " (").concat(o.joinRef(), ")"),
                         o.joinPush.timeout
                       ),
-                      new S(o, T, R({}), o.timeout).send(),
+                      new w(o, T, S({}), o.timeout).send(),
                       (o.state = y),
                       o.joinPush.reset(),
                       o.socket.isConnected() && o.rejoinTimer.scheduleTimeout()
@@ -663,7 +663,7 @@
                             .concat(e, "' to '")
                             .concat(this.topic, "' before joining. Use channel.join() before pushing events")
                         )
-                      var i = new S(
+                      var i = new w(
                         this,
                         e,
                         function () {
@@ -684,7 +684,7 @@
                           e.socket.hasLogger() && e.socket.log("channel", "leave ".concat(e.topic)),
                             e.trigger(k, "leave")
                         },
-                        i = new S(this, T, R({}), t)
+                        i = new w(this, T, S({}), t)
                       return (
                         i
                           .receive("ok", function () {
@@ -927,8 +927,8 @@
                   }),
                   (this.logger = i.logger || null),
                   (this.longpollerTimeout = i.longpollerTimeout || 2e4),
-                  (this.params = R(i.params || {})),
-                  (this.endPoint = "".concat(t, "/").concat(w)),
+                  (this.params = S(i.params || {})),
+                  (this.endPoint = "".concat(t, "/").concat(R)),
                   (this.vsn = i.vsn || "2.0.0"),
                   (this.heartbeatTimer = null),
                   (this.pendingHeartbeatRef = null),
@@ -972,7 +972,7 @@
                           console.log(
                             "passing params to connect is deprecated. Instead pass :params to the Socket constructor"
                           ),
-                        (this.params = R(e))),
+                        (this.params = S(e))),
                         this.conn ||
                           ((this.closeWasClean = !1),
                           (this.conn = new this.transport(this.endPointURL())),
@@ -1315,7 +1315,7 @@
                       return e
                         .replace("ws://", "http://")
                         .replace("wss://", "https://")
-                        .replace(new RegExp("(.*)/" + w), "$1/longpoll")
+                        .replace(new RegExp("(.*)/" + R), "$1/longpoll")
                     },
                   },
                   {

```

</details>


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
